### PR TITLE
Corrected the errors in vendor

### DIFF
--- a/aoscp.dependencies
+++ b/aoscp.dependencies
@@ -9,6 +9,6 @@
    "repository":  "proprietary_vendor_lge",
    "target_path": "vendor/lge",
    "branch":      "n7.1",
-   "branch":      "cm"
+   "remote":      "aicp"
  }
 ]


### PR DESCRIPTION
I used the vendor from here: https://github.com/AICP/proprietary_vendor_lge/tree/n7.1

But I do not see this in aicp gerrit. How do we handle this? We can also get it from https://github.com/TheMuppets/proprietary_vendor_lge/tree/cm-14.1

Nitin